### PR TITLE
Change PKTAPA2 as main mode column in HEHA

### DIFF
--- a/input/modes-heha.csv
+++ b/input/modes-heha.csv
@@ -1,4 +1,4 @@
-﻿id;Paakulkutapa;mode_name;mode
+﻿id;PKTAPA2;mode_name;mode
 1;Kävely (sis. avustavat välineet);ka;1
 2;Polkupyörä;py;2
 3;Auto, kuljettajana;ak;4
@@ -9,5 +9,4 @@
 8;Metro;jl;3
 9;Raitiovaunu;jl;3
 10;Moottoripyörä, mopo, mopoauto, mönkijä;muu;-1
-11;Muu kulkutapa;muu;-1
-12;Auto;am;5
+11;Muu kulku;muu;-1


### PR DESCRIPTION
Like Sampo suggested, `PKTAPA2` is now the main mode column in HEHA analysis. Previously in our analysis, it was `Paakulkutapa` but `PKTAPA2` is the corrected version. If a person uses public transport in his/her trip, it is changed as main mode.
