### PR TITLE
Fix destination search when coordinates are missing

### DIFF
--- a/tours/constants.py
+++ b/tours/constants.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 
 import pandas
+from math import isnan
 
 TYPE_HOME = 1
 TYPE_WORK = 2
@@ -35,6 +36,13 @@ GROUP_NAME = {
 def collapse(list_of_printables, sep=" - "):
     text = sep.join(str(x) for x in list_of_printables)
     return text
+
+
+def if_nan_then(x, y):
+    if isnan(x):
+        return y
+    else:
+        return x
 
 
 def read_people(filepath, survey):

--- a/tours/tour.py
+++ b/tours/tour.py
@@ -171,10 +171,16 @@ class Tour(object):
                 # After home, work, school, and study locations (1-4) all other
                 # location groups are of same priority.
                 groups.append(low_priority)
-                distances.append(origin.eucd(location))
+                distance = origin.eucd(location)
+                # In case of `nan` coordinates, the distance between Locations
+                # is zero. If there are several destination candidates of same
+                # priority, choosing a Location with missing coordinates is
+                # very unlikely.
+                distances.append(constants.if_nan_then(distance, 0.0))
             else:
                 groups.append(group)
-                distances.append(origin.eucd(location))
+                distance = origin.eucd(location)
+                distances.append(constants.if_nan_then(distance, 0.0))
         destination_group = min(groups)
         farthest_distance = -1
         m = -1


### PR DESCRIPTION
Finding destinations worked incorrectly if there were locations with
missing (nan) coordinates. This bug was found when developing a data set
with secondary destinations. Example: a person with pid=100672 made one
trip on survey date which was from leisure (9) to home (1). This
open-ended tour should have home as origin and leisure as destination
and no secondary destination. Instead, the tour had home as both origin
and destination, and leisure as secondary destination. This commit fixes
this bad behavior!