### PR TITLE
Discard duplicate calibration results

### DIFF
--- a/batch.sh
+++ b/batch.sh
@@ -58,9 +58,7 @@ cp -ruv generation/*.csv $OUTPUT/
 cp -ruv metropolitan/primary/weights.csv $OUTPUT/weights-metropolitan.csv
 cp -ruv peripheral/primary/weights.csv $OUTPUT/weights-peripheral.csv
 
-mkdir $OUTPUT/calibration
-cp -ruv calibration/output/*.txt $OUTPUT/calibration/
-cp -ruv calibration/output/*.xlsx $OUTPUT/calibration/
+cp -ruv calibration/output/*.xlsx $OUTPUT/
 
 cp -ruv shares/shares.csv $OUTPUT/
 


### PR DESCRIPTION
Only the Excel file is saved as output. More results will be saved if there is a need.