### PR TITLE
Feat/update docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@ RUN apt-get update && apt-get install -y \
   libproj-dev \
   libssh2-1-dev \
   libssl-dev \
+  nano \
   proj-bin \
   proj-data
 RUN R --no-save --encoding=UTF-8 -f install-dependencies.R

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM r-base:3.6.0
+FROM rocker/r-ver:3.6.0
 
 WORKDIR /helmet-data-preprocessing
 


### PR DESCRIPTION
The previous `r-base` image was not version-controlled in Debian's side. This PR improves version-controlling, allowing image to be more stable.