### PR TITLE
Install strafica from public source

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,9 +7,6 @@
 # Sensitive information
 survey/*.csv
 
-# Proprietary libraries
-strafica/
-
 # Output files
 *.RData
 *.csv

--- a/.gitignore
+++ b/.gitignore
@@ -8,9 +8,6 @@
 /survey/*.csv
 /survey/*.RData
 
-# Proprietary libraries
-/strafica/
-
 # Output files
 *.RData
 *.csv

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Please note, that scripts use encoding `UTF-8`.
 R and Python environment is virtualized using Docker. See
 [Dockerfile](Dockerfile) for details. Build and run using commands below.
 Run-script will open up a bash session where user can start the preprocessing.
-External dependencies and the data need to be however mapped as external volume,
+The data needs to be however mapped as external volume,
 see `docker run` commands below.
 
 ### Build Docker image
@@ -41,7 +41,6 @@ the end of the repository address.
 docker run -it --rm `
   -v c:/Users/xxx/input:/input `
   -v c:/Users/xxx/output:/output `
-  -v c:/Users/xxx/strafica:/strafica `
   helmet-data-preprocessing
 ```
 
@@ -51,21 +50,18 @@ docker run -it --rm `
 docker run -it --rm \
   -v ~/xxx/input:/input \
   -v ~/xxx/output:/output \
-  -v ~/xxx/strafica:/strafica \
   helmet-data-preprocessing
 ```
 
 ### External dependencies
 
-R-scripts use proprietary library called `strafica` which needs to be installed
-separately. `strafica` package can be found from the office for selected people
-to use. You can check dependencies from the DESCRIPTION file or from the
-[Dockerfile](Dockerfile) and then install it:
+You can install dependencies with:
 
 ```
 Rscript --quiet --no-save --encoding=UTF-8 install-dependencies.R
-(cd strafica && Rscript --quiet --no-save --encoding=UTF-8 install.R)
 ```
+
+Dockerfile installs these dependencies automatically.
 
 ### Input data
 

--- a/install-dependencies.R
+++ b/install-dependencies.R
@@ -6,6 +6,8 @@ install.packages("devtools")
 require(devtools)
 cran = "https://ftp.eenet.ee/pub/cran/"
 
+Sys.setenv(R_REMOTES_UPGRADE = "never") 
+
 # strafica dependencies
 install_version("data.table", version="1.12.2", repos=cran)
 install_version("ggplot2", version="3.1.1", repos=cran)
@@ -18,8 +20,13 @@ install_version("rgeos", version="0.4-3", repos=cran)
 install_version("sp", version="1.3-1", repos=cran)
 install_version("magrittr", version="1.5", repos=cran)
 
+# strafica package
+install_github("Ramboll/strafica@44e17fc")
+
 # helmet-data-preprocessing -specific dependencies
 install_version("readxl", version="1.3.1", repos=cran)
 install_version("lubridate", version="1.7.4", repos=cran)
 install_version("tidyr", version="0.8.3", repos=cran)
 install_version("writexl", version="1.1", repos=cran)
+
+print(installed.packages()[, c("Package", "Version", "Built")])


### PR DESCRIPTION
The strafica package was recently released as open-source here: https://github.com/Ramboll/strafica This PR will streamline Docker image building process by installing strafica straight from Github.
